### PR TITLE
Adição do terceiro princípio SOLID: O Princípio da Substituição de Li…

### DIFF
--- a/src/main/java/br/com/api/abstracts/ContactAbstract.java
+++ b/src/main/java/br/com/api/abstracts/ContactAbstract.java
@@ -1,4 +1,4 @@
-package br.com.api.entity;
+package br.com.api.abstracts;
 
 import javax.persistence.*;
 

--- a/src/main/java/br/com/api/abstracts/SsdAbstract.java
+++ b/src/main/java/br/com/api/abstracts/SsdAbstract.java
@@ -1,0 +1,80 @@
+package br.com.api.abstracts;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import br.com.api.entity.Category;
+import br.com.api.entity.Client;
+import br.com.api.entity.Cpu;
+import br.com.api.entity.File;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Table(name = "SSD")
+@Entity
+public abstract class SsdAbstract {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "SSD_ID")
+    private Long id;
+
+    @Column(name = "brand")
+    @NotNull
+    private String brand;
+
+    @Column(name = "serial_number", length = 17)
+    @NotNull
+    private String serialNumber;
+
+    @NotNull
+    @Column(name = "size_storage", length = 4)
+    private String size;
+
+    @NotNull
+    @Column(name = "purchase_price")
+    private String purchasePrice;
+
+    @NotNull
+    @Column(name = "purchase_date")
+    private String purchaseDate;
+
+    @NotNull
+    @Column(name = "sale_value")
+    private float saleValue;
+
+    @Column(name = "arrival_date")
+    private String arrivalDate;
+
+    @Column(name = "url")
+    private String url;
+
+    @Column(name = "amount")
+    private int amount;
+
+    @NotNull
+    @Column(name = "model")
+    private String model;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SSD_ID")
+    private File image;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SSD_ID")
+    private Category category;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CPU_ID")
+    private Cpu cpu;
+
+    @JsonIgnore
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SSD_ID")
+    private Client client;
+}

--- a/src/main/java/br/com/api/entity/Category.java
+++ b/src/main/java/br/com/api/entity/Category.java
@@ -2,6 +2,7 @@ package br.com.api.entity;
 
 import javax.persistence.*;
 
+import br.com.api.abstracts.SsdAbstract;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -25,7 +26,7 @@ public class Category {
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "SSD_ID")
-    private Ssd ssd;
+    private SsdAbstract ssdAbstract;
 
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/br/com/api/entity/Client.java
+++ b/src/main/java/br/com/api/entity/Client.java
@@ -1,5 +1,6 @@
 package br.com.api.entity;
 
+import br.com.api.abstracts.SsdAbstract;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -49,6 +50,6 @@ public class Client {
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "SSD_ID")
-    private Ssd ssd;
+    private SsdAbstract ssdAbstract;
 
 }

--- a/src/main/java/br/com/api/entity/Contact.java
+++ b/src/main/java/br/com/api/entity/Contact.java
@@ -1,11 +1,11 @@
 package br.com.api.entity;
 
+import br.com.api.abstracts.ContactAbstract;
+
 import javax.persistence.Entity;
 
 @Entity
-//@Table(name = "contact")
 public class Contact extends ContactAbstract {
 
-	// Herda de SacAbstract
 
 }

--- a/src/main/java/br/com/api/entity/File.java
+++ b/src/main/java/br/com/api/entity/File.java
@@ -2,6 +2,7 @@ package br.com.api.entity;
 
 import javax.persistence.*;
 
+import br.com.api.abstracts.SsdAbstract;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -38,7 +39,7 @@ public class File {
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "SSD_ID")
-    private Ssd ssd;
+    private SsdAbstract ssdAbstract;
 
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/br/com/api/entity/Ssd.java
+++ b/src/main/java/br/com/api/entity/Ssd.java
@@ -1,76 +1,10 @@
 package br.com.api.entity;
 
-import javax.persistence.*;
-import javax.validation.constraints.NotNull;
+import br.com.api.abstracts.SsdAbstract;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import javax.persistence.Entity;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
-@Table(name = "SSD")
 @Entity
-public class Ssd {
+public class Ssd extends SsdAbstract {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "SSD_ID")
-    private Long id;
-
-    @Column(name = "brand")
-    @NotNull
-    private String brand;
-
-    @Column(name = "serial_number", length = 17)
-    @NotNull
-    private String serialNumber;
-
-    @NotNull
-    @Column(name = "size_storage", length = 4)
-    private String size;
-
-    @NotNull
-    @Column(name = "purchase_price")
-    private String purchasePrice;
-
-    @NotNull
-    @Column(name = "purchase_date")
-    private String purchaseDate;
-
-    @NotNull
-    @Column(name = "sale_value")
-    private float saleValue;
-
-    @Column(name = "arrival_date")
-    private String arrivalDate;
-
-    @Column(name = "url")
-    private String url;
-
-    @Column(name = "amount")
-    private int amount;
-
-    @NotNull
-    @Column(name = "model")
-    private String model;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "SSD_ID")
-    private File image;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "SSD_ID")
-    private Category category;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "CPU_ID")
-    private Cpu cpu;
-
-    @JsonIgnore
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "SSD_ID")
-    private Client client;
 }


### PR DESCRIPTION
…skov estabelece que os objetos de uma classe derivada devem ser capazes de substituir os objetos da classe base sem afetar a integridade do sistema. Em outras palavras, os objetos das subclasses devem ser substituíveis pelos objetos da classe base sem alterar o comportamento esperado do programa.

Ssd entity agora herda de SsdAbstract, assim agora faz parte do terceiro princípio, junto da classe Client.